### PR TITLE
test(sync): assert pull 200 before deviceSyncState checks

### DIFF
--- a/api-server/src/tests/sync.test.ts
+++ b/api-server/src/tests/sync.test.ts
@@ -350,7 +350,12 @@ describe('GET /sync/pull', () => {
         // Explicit-ack protocol: server records `ackedTs` (what the client has durably persisted),
         // not the response's `serverTs`. Client typically passes `ackedTs === since === IDB cursor`.
         const ackedTs = '2025-01-15T00:00:00.000Z';
-        await pull(cookie, { since: ackedTs, ackedTs, deviceId: 'dev-2' });
+        // Assert the pull itself succeeded before inspecting its DB side-effect. The handler awaits
+        // the deviceSyncState upsert before responding, so a 200 guarantees the row exists; without
+        // this guard a transient 500 (e.g. a Mongo hiccup under CI load) surfaces downstream as a
+        // cryptic `state === undefined` instead of the real HTTP failure.
+        const res = await pull(cookie, { since: ackedTs, ackedTs, deviceId: 'dev-2' });
+        expect(res.status).toBe(200);
 
         const state = await db.collection('deviceSyncState').findOne({ _id: `dev-2::${userId}` });
         expect(state?.lastSyncedTs).toBe(ackedTs);
@@ -361,7 +366,9 @@ describe('GET /sync/pull', () => {
     it('pull without deviceId does not create a deviceSyncState doc', async () => {
         const cookie = await loginAsAlice();
 
-        await pull(cookie);
+        // Guard the negative assertion: a 500 would also leave zero docs, falsely "passing".
+        const res = await pull(cookie);
+        expect(res.status).toBe(200);
 
         expect(await db.collection('deviceSyncState').countDocuments()).toBe(0);
     });


### PR DESCRIPTION
## Why

CI run [27072373449](https://github.com/yuval-yssak/gtd-app/actions/runs/27072373449) flaked at `sync.test.ts:356` — `expect(state?.lastSyncedTs).toBe(ackedTs)` received `undefined`.

It was a **flake, not a regression**: the triggering commit (`0715889`) changed only `deploy-api.yml` (no source/test code), and the test passes locally in isolation, full-file, and 10× repeated.

Root cause of the cryptic symptom: the `/sync/pull` handler awaits the `deviceSyncState` upsert before returning 200, so a transient 500 (e.g. a Mongo hiccup under CI load) leaves no row — which then surfaces downstream as `state === undefined` instead of the real HTTP failure.

## What

In the two tests that discard the pull response and then assert on a DB side-effect, capture the response and assert `status === 200` first:

- **`pull with deviceId updates deviceSyncState…`** — the test that flaked.
- **`pull without deviceId does not create a deviceSyncState doc`** — a negative assertion a 500 would also satisfy (zero docs), silently masking the failure.

This makes any future transient failure surface as a clear status mismatch rather than a misleading `undefined` / falsely-passing zero-count.

Test-only change. `lint:fix` / `typecheck` / full sync suite green; api-code-reviewer approved.

> Note: this does not fix the red on `main` (that flake was on `0715889`) — that just needs a CI re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)